### PR TITLE
Update README with links to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 gdx-collections
 ======================
-LibGDX collection classes extracted into a standalone library (i.e. no OpenGL, LWJGL, etc. required)
+[LibGDX](https://libgdx.badlogicgames.com/) [collection classes](https://github.com/libgdx/libgdx/wiki/Collections) extracted into a standalone library (i.e. no OpenGL, LWJGL, etc. required)
+
+This is useful for those who need high performance collections on the JVM but aren't building an application with LibGDX.
 
 Mechanism
 ----------------------
@@ -19,45 +21,43 @@ compile "org.mini2Dx:gdx-collections:1.9.8"
 Included Classes
 ----------------------
 
- * Array
- * ArrayMap
- * AtomicQueue
- * Bits
- * BooleanArray
- * ByteArray
- * CharArray
- * ComparableTimSort
- * DelayedRemovalArray
- * Disposable
- * FloatArray
- * FlushablePool
- * GdxRuntimeException
- * IdentityMap
- * IntArray
- * IntFloatMap
- * IntIntMap
- * IntMap
- * IntSet
- * LongArray
- * LongMap
- * NumberUtils
- * ObjectFloatMap
- * ObjectIntMap
- * ObjectMap
- * ObjectSet
- * OrderedMap
- * OrderedSet
- * Pool
- * PooledLinkedList
- * Pools
- * Predicate
- * Queue
- * QuickSelect
- * ReflectionPool
- * Select
- * ShortArray
- * SnapshotArray
- * Sort
- * SortedIntList
- * TimSort
- * TimeUtils
+ * [Array](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/Array.html)
+ * [ArrayMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/ArrayMap.html)
+ * [AtomicQueue](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/AtomicQueue.html)
+ * [Bits](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/Bits.html)
+ * [BooleanArray](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/BooleanArray.html)
+ * [ByteArray](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/ByteArray.html)
+ * [CharArray](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/CharArray.html)
+ * [DelayedRemovalArray](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/DelayedRemovalArray.html)
+ * [Disposable](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/Disposable.html)
+ * [FloatArray](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/FloatArray.html)
+ * [FlushablePool](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/FlushablePool.html)
+ * [GdxRuntimeException](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/GdxRuntimeException.html)
+ * [IdentityMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/IdentityMap.html)
+ * [IntArray](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/IntArray.html)
+ * [IntFloatMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/IntFloatMap.html)
+ * [IntIntMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/IntIntMap.html)
+ * [IntMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/IntMap.html)
+ * [IntSet](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/IntSet.html)
+ * [LongArray](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/LongArray.html)
+ * [LongMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/LongMap.html)
+ * [NumberUtils](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/NumberUtils.html)
+ * [ObjectFloatMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/ObjectFloatMap.html)
+ * [ObjectIntMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/ObjectIntMap.html)
+ * [ObjectMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/ObjectMap.html)
+ * [ObjectSet](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/ObjectSet.html)
+ * [OrderedMap](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/OrderedMap.html)
+ * [OrderedSet](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/OrderedSet.html)
+ * [Pool](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/Pool.html)
+ * [PooledLinkedList](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/PooledLinkedList.html)
+ * [Pools](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/Pools.html)
+ * [Predicate](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/Predicate.html)
+ * [Queue](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/Queue.html)
+ * [QuickSelect](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/QuickSelect.html)
+ * [ReflectionPool](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/ReflectionPool.html)
+ * [Select](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/Select.html)
+ * [ShortArray](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/ShortArray.html)
+ * [SnapshotArray](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/SnapshotArray.html)
+ * [Sort](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/Sort.html)
+ * [SortedIntList](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/SortedIntList.html)
+ * [TimeUtils](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/utils/TimeUtils.html)


### PR DESCRIPTION
This also removes the package private classes from the list of included classes (ComparableTimSort and TimSort). I can easily add them back in, but having them there we should probably also mention MathUtils and RandomXS128.